### PR TITLE
连接触发判断一下，处于连接状态才去获取browse节点

### DIFF
--- a/OpcUaHelper/Forms/FormBrowseServer.cs
+++ b/OpcUaHelper/Forms/FormBrowseServer.cs
@@ -150,9 +150,13 @@ namespace OpcUaHelper.Forms
         {
             try
             {
-                // populate the browse view.
-                PopulateBranch(ObjectIds.ObjectsFolder, BrowseNodesTV.Nodes);
-                BrowseNodesTV.Enabled = true;
+                OpcUaClient client = (OpcUaClient)sender;
+                if (client.Connected)
+                {
+                    // populate the browse view.
+                    PopulateBranch(ObjectIds.ObjectsFolder, BrowseNodesTV.Nodes);
+                    BrowseNodesTV.Enabled = true;
+                }
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
我注意到连接函数Connect最开始会调用一下Disconnect，因此会在连接事件回调M_OpcUaClient_ConnectComplete里调用到PopulateBranch，此时OpcUaClient的m_session还是null，会触发一个异常，虽然M_OpcUaClient_ConnectComplete有try catch，但是vs调试时会经常因为这个异常而中断，这里用Connected值判断一下再进入PopulateBranch就不会抛异常了。

另外，EventArgs参数不管是否连接始终被设置为null，我觉得你以后会来处理这个问题吧，就没有在完善EventArgs参数上来处理这个问题